### PR TITLE
Simplified code flow. prod(wut, zzz) and poke(wut) throwing exceptions.

### DIFF
--- a/src/medianizer.sol
+++ b/src/medianizer.sol
@@ -48,7 +48,7 @@ contract Medianizer is DSCache, MedianizerEvents {
         has = true;
     }
 
-    function poke(bytes32) {
+    function poke(bytes32) auth {
         throw; // so we can not overwrite the computed value
     }
 

--- a/src/medianizer.sol
+++ b/src/medianizer.sol
@@ -49,11 +49,16 @@ contract Medianizer is DSCache, MedianizerEvents {
     }
 
     function poke(bytes32) {
-        poke();
+        throw; // so we can not overwrite the computed value
     }
 
     function prod(uint128 Zzz) {
-        prod(0, Zzz);
+        poke();
+        zzz = Zzz;
+    }
+
+    function prod(bytes32, uint128) {
+        throw; // so we can not overwrite the computed value
     }
 
     function compute() internal constant returns (bytes32) {

--- a/src/test.sol
+++ b/src/test.sol
@@ -202,4 +202,12 @@ contract Test is DSTest {
         m.prod(0);
         m.read();
     }
+
+    function testFailPoke() {
+        m.poke(60 ether);
+    }
+
+    function testFailProd() {
+        m.prod(60 ether, zzz);
+    }
 }


### PR DESCRIPTION
In the previous approach, prod(uint128 Zzz) did go via two inherited functions before actually getting back to medianizer code. Now the code flow can be followed more easily as it doesn't use the inherited code.

Additionally, we override the inherited methods so it's not possible to manipulate the value in the medianizer. Added unit tests for it.